### PR TITLE
Updated docker file to use slim-buster image instead of alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
-FROM python:3.8-alpine
+FROM python:3.8-slim-buster
 LABEL maintainer="Keyko <root@keyko.io>"
 
 ARG VERSION
 
-RUN apk add --no-cache --update \
-    build-base \
-    gcc \
-    libffi-dev \
-    openssl-dev
-
-RUN pip install nevermined-sdk-py web3
+RUN apt-get update \
+    && apt-get install gcc -y \
+    && apt-get clean
 
 COPY . /nevermined-pod-publishing
 WORKDIR /nevermined-pod-publishing


### PR DESCRIPTION
Updated dockerfile to use `slim-buster` instead of `alpine`
Fixes a dependency problem when installing web3