### PR TITLE
Adds the executionId to the output ddo metadata

### DIFF
--- a/nevermined_pod_publishing/pod_publishing.py
+++ b/nevermined_pod_publishing/pod_publishing.py
@@ -1,3 +1,4 @@
+import os
 import argparse
 import json
 import logging
@@ -123,7 +124,10 @@ def run(args):
             "author": "pod-publishing",
             "license": "No License Specified",
             "price": "1",
-            "metadata": workflow.metadata,
+            "metadata": {
+                "workflow": workflow.metadata,
+                "executionId": os.getenv("EXECUTION_ID")
+            },
             "files": files,
             "type": "dataset",
         }


### PR DESCRIPTION
- The execution id is added to the metadata of the output ddo to allow us to query for the ddo by executionId